### PR TITLE
[4.6.1] AMQPProducer reliability

### DIFF
--- a/src/main/java/com/abiquo/commons/amqp/AMQPConfiguration.java
+++ b/src/main/java/com/abiquo/commons/amqp/AMQPConfiguration.java
@@ -14,7 +14,7 @@ import com.rabbitmq.client.Channel;
 /**
  * Generic broker configuration, each module configuration must extend this class and fill the
  * abstract methods.
- * 
+ *
  * @author eruiz@abiquo.com
  */
 public abstract class AMQPConfiguration

--- a/src/main/java/com/abiquo/commons/amqp/consumer/AMQPConsumer.java
+++ b/src/main/java/com/abiquo/commons/amqp/consumer/AMQPConsumer.java
@@ -80,8 +80,9 @@ public class AMQPConsumer<C extends Serializable> implements Closeable
         log.trace("Setting Qos to {} for {}", configuration.getPrefetchCount(), this);
         channel.basicQos(configuration.getPrefetchCount());
 
-        log.trace("Declaring exhanges for {}", this);
+        log.trace("Declaring exchanges for {}", this);
         configuration.declareExchanges(channel);
+
         log.trace("Declaring queues for {}", this);
         configuration.declareQueues(channel);
 

--- a/src/main/java/com/abiquo/commons/amqp/producer/AMQPProducerConfirm.java
+++ b/src/main/java/com/abiquo/commons/amqp/producer/AMQPProducerConfirm.java
@@ -63,7 +63,6 @@ public class AMQPProducerConfirm<T extends Serializable> extends AMQPProducer<T>
         {
             @Override
             public void handleNack(final long deliveryTag, final boolean multiple)
-                throws IOException
             {
                 log.trace("NACK message with delivery tag: {} multiple: {}", deliveryTag, multiple);
 
@@ -84,7 +83,7 @@ public class AMQPProducerConfirm<T extends Serializable> extends AMQPProducer<T>
             }
 
             @Override
-            public void handleAck(final long deliveryTag, final boolean multiple) throws IOException
+            public void handleAck(final long deliveryTag, final boolean multiple)
             {
                 log.trace("ACK message with delivery tag: {} multiple: {}", deliveryTag, multiple);
 

--- a/src/main/java/com/abiquo/commons/amqp/producer/AMQPProducerConfirm.java
+++ b/src/main/java/com/abiquo/commons/amqp/producer/AMQPProducerConfirm.java
@@ -110,10 +110,10 @@ public class AMQPProducerConfirm<T extends Serializable> extends AMQPProducer<T>
         {
             super.publish(message);
         }
-        catch (IOException e)
+        catch (Throwable throwable)
         {
             notConfirmedMessages.remove(nextSeqNo);
-            throw e;
+            propagate(throwable);
         }
     }
 }

--- a/src/main/java/com/abiquo/commons/amqp/producer/AMQPProducerConfirm.java
+++ b/src/main/java/com/abiquo/commons/amqp/producer/AMQPProducerConfirm.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2008 - Abiquo Holdings S.L. All rights reserved.
+ *
+ * Please see /opt/abiquo/tomcat/webapps/legal/ on Abiquo server
+ * or contact contact@abiquo.com for licensing information.
+ */
+package com.abiquo.commons.amqp.producer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.abiquo.commons.amqp.AMQPConfiguration;
+import com.abiquo.commons.amqp.serialization.AMQPSerializer;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.ConfirmListener;
+
+/**
+ * This {@link AMQPProducer} publish and confirm the successfully publication of messages. A
+ * fallback should be specified in order to handle not confirmed messages from broker and the not
+ * published messages due to connection errors.
+ * <h2>Concurrency Considerations</h2>
+ * <p>
+ * Remember that AMQP {@link Channel} instances must not be shared between threads.
+ * </p>
+ * <h2>Use Considerations</h2>
+ * <p>
+ * The {@link Channel} instance must be configured to manage acknowledgements. See method
+ * {@link Channel#confirmSelect()}
+ * </p>
+ * <p>
+ * To successfully process all messages confirmations, your code must wait for all confirmations
+ * using the {@link Channel} methods: {@link Channel#waitForConfirms()},
+ * {@link Channel#waitForConfirms(long)}, {@link Channel#waitForConfirmsOrDie()} or
+ * {@link Channel#waitForConfirmsOrDie(long)}
+ * </p>
+ *
+ * @param <T> the type of the objects to publish
+ */
+public class AMQPProducerConfirm<T extends Serializable> extends AMQPProducer<T>
+{
+    private final static Logger log = LoggerFactory.getLogger(AMQPProducerConfirm.class);
+
+    private final Map<Long, T> notConfirmedMessages = new ConcurrentHashMap<>();
+
+    public AMQPProducerConfirm(final AMQPConfiguration configuration, final Channel channel,
+        final AMQPSerializer<T> serializer, final Consumer<T> fallback)
+    {
+        super(configuration, channel, serializer, fallback);
+
+        channel.clearConfirmListeners();
+
+        channel.addConfirmListener(new ConfirmListener()
+        {
+            @Override
+            public void handleNack(final long deliveryTag, final boolean multiple)
+                throws IOException
+            {
+                log.trace("NACK message with delivery tag: {} multiple: {}", deliveryTag, multiple);
+
+                List<T> unpublished = new ArrayList<>();
+
+                unpublished.add(notConfirmedMessages.remove(deliveryTag));
+
+                if (!multiple)
+                {
+                    return;
+                }
+
+                for (long i = 0; i < deliveryTag; i++)
+                {
+                    T message = notConfirmedMessages.remove(deliveryTag);
+                    if (message != null)
+                    {
+                        unpublished.add(message);
+                    }
+                }
+
+                unpublished.forEach(fallback);
+            }
+
+            @Override
+            public void handleAck(final long deliveryTag, final boolean multiple) throws IOException
+            {
+                log.trace("ACK message with delivery tag: {} multiple: {}", deliveryTag, multiple);
+
+                notConfirmedMessages.remove(deliveryTag);
+
+                for (long i = deliveryTag - 1; multiple && notConfirmedMessages.remove(i) != null
+                    && i >= 0; i--)
+                {
+                }
+            }
+        });
+    }
+
+    @Override
+    public void publish(final T message) throws IOException
+    {
+        checkNotNull(message, "Message to publish can not be null");
+
+        long nextSeqNo = channel.getNextPublishSeqNo();
+        notConfirmedMessages.put(nextSeqNo, message);
+
+        try
+        {
+            super.publish(message);
+        }
+        catch (IOException e)
+        {
+            notConfirmedMessages.remove(nextSeqNo);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/abiquo/commons/amqp/producer/AMQPProducerConfirm.java
+++ b/src/main/java/com/abiquo/commons/amqp/producer/AMQPProducerConfirm.java
@@ -71,12 +71,7 @@ public class AMQPProducerConfirm<T extends Serializable> extends AMQPProducer<T>
 
                 unpublished.add(notConfirmedMessages.remove(deliveryTag));
 
-                if (!multiple)
-                {
-                    return;
-                }
-
-                for (long i = 0; i < deliveryTag; i++)
+                for (long i = 0; multiple && i < deliveryTag; i++)
                 {
                     T message = notConfirmedMessages.remove(deliveryTag);
                     if (message != null)


### PR DESCRIPTION
- AMQPProducer declare queues configuration
Although we don't use AMQP 'mandatory' flag in the AMQPProducer, it is OK to
force the queue declaration in producers.

- AMQP publish could confirm a publish
Implemented as new AMQPProducer -> AMQPProducerConfirm

- Added a publish fallback to handle unsuccessfully publish of a message due
to connection errors or due to negative confirms from RabbitMQ broker.

https://jira.abiquo.com/browse/ABICLOUDPREMIUM-12123